### PR TITLE
Fix for selected glyphs crash + fix for using the wrong characters to select words

### DIFF
--- a/word-o-mat.glyphsPlugin/Contents/Info.plist
+++ b/word-o-mat.glyphsPlugin/Contents/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.5.5</string>
 	<key>NSHumanReadableCopyright</key>

--- a/word-o-mat.glyphsPlugin/Contents/Resources/WordOMat.py
+++ b/word-o-mat.glyphsPlugin/Contents/Resources/WordOMat.py
@@ -348,7 +348,7 @@ class WordomatWindow:
         for g in font.glyphs:
             if g.unicode is not None:
                 try:
-                    charset.append(unichr(int(g.unicode)))
+                    charset.append(unichr(int(g.unicode, 16)))
                     gnames.append(g.name)
                 except ValueError:
                     pass
@@ -374,7 +374,7 @@ class WordomatWindow:
                     g = self.f.glyphs[c]
                     if g:
                         try:
-                            value = unicode(unichr(int(g.unicode)))
+                            value = unicode(unichr(int(g.unicode, 16)))
                             result2.append(value)
                         except TypeError: # unicode not set
                             Message(title="word-o-mat", message="Glyph \"%s\" was found, but does not appear to have a Unicode value set. It can therefore not be processed, and will be skipped." % c)
@@ -580,10 +580,10 @@ class WordomatWindow:
             else:
                 try:
                     self.customCharset = []
-                    for gname in self.f.selection:
-                        if self.f[gname].unicode is not None:
+                    for g in self.f.selection:
+                        if g.unicode is not None:
                             try: 
-                                self.customCharset.append(unichr(int(self.f[gname].unicode)))
+                                self.customCharset.append(unichr(int(g.unicode, 16)))
                             except ValueError:
                                 pass 
                 except AttributeError: 


### PR DESCRIPTION
Fixes selected glyphs issue per:
https://forum.glyphsapp.com/t/word-o-mat-broken-in-2-5/8684/27

Plus, found another bug: converting the glyph.unicode string as a base 10 integer instead of base 16 (hex). Added base argument to int() function call.

Increased build number to 11.